### PR TITLE
docs: add edX to courses section

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ It makes it easier for new people to find this repository.
 - [freeCodeCamp.org](https://freecodecamp.org)
 - [JavaScript 30](https://javascript30.com/)
 - [Test Automation University](https://testautomationu.applitools.com/)
+- [edX](https://www.edx.org/)
 
 ## CSS
 


### PR DESCRIPTION
Hi, I just added to the courses section edX. It offers courses from major universities like Harvard. They can be free or the user can upgrade if they would like an official certificate. 