### PR TITLE
add: open trivia db to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ It makes it easier for new people to find this repository.
 ## APIs
 
 - [JSON Placeholder](https://jsonplaceholder.typicode.com/)
+- [Open Trivia Database](https://opentdb.com/)
 - [OpenWeather](https://openweathermap.org/guide)
 - [Public API List](https://github.com/public-apis/public-apis)
 - [The Star Wars API](https://swapi.dev/)


### PR DESCRIPTION
- Open Trivia Database - https://opentdb.com/

Free to use, user-contributed trivia question database with over 4,098 verified questions. No API key required