### PR TITLE
Adds Pinterest, Netflix, Spotify, Pragmatic Engineer blogs and Software Engineering Radio podcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,12 @@ It makes it easier for new people to find this repository.
 - [CSS Tricks](https://css-tricks.com/)
 - [Dev.to](https://dev.to/)
 - [Flavio Copes](https://flaviocopes.com/)
+- [Netflix Tech Blog](https://netflixtechblog.com)
+- [Pinterest Engineering](https://medium.com/pinterest-engineering)
 - [Scotch.io](https://scotch.io)
 - [Smashing Magazine](https://www.smashingmagazine.com/articles/)
+- [Spotify Engineering](https://engineering.atspotify.com)
+- [The Pragmatic Engineer](https://blog.pragmaticengineer.com)
 
 ## Books
 
@@ -321,6 +325,7 @@ It makes it easier for new people to find this repository.
 - [Full Stack Radio](https://fullstackradio.com/)
 - [JS Party](https://changelog.com/jsparty)
 - [Ladybug](https://www.ladybug.dev/)
+- [Software Engineering Radio](https://www.se-radio.net)
 - [Syntax.fm](https://syntax.fm)
 
 ## Practice


### PR DESCRIPTION
## Changes proposed

Adds the following blogs:

- [Netflix Tech Blog](https://netflixtechblog.com)
- [Pinterest Engineering](https://medium.com/pinterest-engineering)
- [Spotify Engineering](https://engineering.atspotify.com)
- [The Pragmatic Engineer](https://blog.pragmaticengineer.com)

Adds the following podcasts:

- [Software Engineering Radio](https://www.se-radio.net)

## Check List

- [x] The title of my pull request is a short description of the requested changes.
- [x] I followed the [Contributing Guidelines](https://github.com/codu-code/codu/blob/develop/CONTRIBUTING.md) 
